### PR TITLE
send_pb - do not convert amount to float

### DIFF
--- a/cli/twitter/send_pb.php
+++ b/cli/twitter/send_pb.php
@@ -10,7 +10,7 @@ require_once '_bootstrap.php';
 // ]));
 
 $to = preg_replace("@[^a-zA-Z0-9_\.-]@", "", (string) @$argv[1]);
-$amount = preg_replace("@\.$@", "", preg_replace("@[0]+$@", "", number_format(preg_replace("@[^0-9,\.]@", "", @$argv[2]), 8, '.', '')));
+$amount = preg_replace("@\.$@", "", preg_replace("@[0]+$@", "", number_format(preg_replace("@[^0-9,\.]@", "", number_format( (float) @$argv[2], 6 ) ), 8, '.', '')));
 
 $user = @$twitter_call('users/lookup', 'GET', [ 'screen_name' => $to ])[0]->id;
 if (!empty($user)) {

--- a/cli/twitter/send_pb.php
+++ b/cli/twitter/send_pb.php
@@ -10,7 +10,7 @@ require_once '_bootstrap.php';
 // ]));
 
 $to = preg_replace("@[^a-zA-Z0-9_\.-]@", "", (string) @$argv[1]);
-$amount = preg_replace("@\.$@", "", preg_replace("@[0]+$@", "", number_format(preg_replace("@[^0-9,\.]@", "", (float) @$argv[2]), 8, '.', '')));
+$amount = preg_replace("@\.$@", "", preg_replace("@[0]+$@", "", number_format(preg_replace("@[^0-9,\.]@", "", @$argv[2]), 8, '.', '')));
 
 $user = @$twitter_call('users/lookup', 'GET', [ 'screen_name' => $to ])[0]->id;
 if (!empty($user)) {


### PR DESCRIPTION
**Not tested** ❗️ 

Prior to this change, a deposit of 0.000001 XRP displays as 1.06 XRP. I assume this is because `0.000001` is converted to `1e-6` (exponential notation for float) which is then interpreted as `1.06`. I could be wrong about this, though! I didn't run the code and this change has NOT been tested. I'm submitting this PR because I think this is the right place to look - but this needs further evaluation and testing before merging.